### PR TITLE
Testing library dom v8

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
   "license": "MIT",
   "dependencies": {
     "@babel/runtime": "^7.12.5",
-    "@testing-library/dom": "^7.26.6",
+    "@testing-library/dom": "^8.5.0",
     "@vue/test-utils": "^1.1.0"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "setup": "npm install && npm run validate -s"
   },
   "engines": {
-    "node": ">10.18"
+    "node": ">=12"
   },
   "files": [
     "types/*.d.ts",


### PR DESCRIPTION
This updates the version of `@testing-library/dom` from v7 to v8 for Vue 2.x.

- Since the v8 version dropped support for Node 10, I cherry-picked this change as well.
- Using `^8.5.0` to be consistent with the Vue 3 version of the library.
- Tested this change on a large Nuxt 2 repo and everything worked as expected.

**Issues**
- It's a bit unclear which branch this should be targeting. Both `main` and `next` are seemingly only for Vue 3.
- There's an error when running `npm run validate`, unrelated to this change:
```
[typecheck] Error: Errors in typescript@4.9 for external dependencies:
[typecheck] ../node_modules/@types/inquirer/index.d.ts(80,76): error TS2344: Type 'T' does not satisfy the constraint 'Answers'.
[typecheck] ../node_modules/@types/inquirer/index.d.ts(84,91): error TS2344: Type 'TChoiceMap' does not satisfy the constraint 'Answers'.
[typecheck] ../node_modules/@types/inquirer/index.d.ts(84,105): error TS2344: Type 'T' does not satisfy the constraint 'Answers'.
[typecheck] ../node_modules/@types/inquirer/index.d.ts(139,43): error TS2344: Type 'T' does not satisfy the constraint 'Answers'.
[typecheck] ../node_modules/@types/inquirer/lib/objects/choices.d.ts(11,39): error TS2344: Type 'T' does not satisfy the constraint 'Answers'.
[typecheck] ../node_modules/@types/inquirer/lib/objects/choices.d.ts(11,61): error TS2344: Type 'T' does not satisfy the constraint 'Answers'.
[typecheck]
[typecheck]     at /vue-testing-library/node_modules/dtslint/bin/index.js:207:19
[typecheck]     at Generator.next (<anonymous>)
[typecheck]     at fulfilled (/vue-testing-library/node_modules/dtslint/bin/index.js:6:58)
[typecheck] npm run typecheck --silent exited with code 1
husky > pre-commit hook failed (add --no-verify to bypass)
```
